### PR TITLE
created markket content type and associated resources

### DIFF
--- a/src/api/markket/content-types/markket/schema.json
+++ b/src/api/markket/content-types/markket/schema.json
@@ -4,7 +4,7 @@
   "info": {
     "singularName": "markket",
     "pluralName": "markkets",
-    "displayName": "markket",
+    "displayName": "Markket",
     "description": "Instance of a markket - usage records"
   },
   "options": {
@@ -17,17 +17,12 @@
       "required": true
     },
     "Content": {
+      "type": "json",
+      "required": true
+    },
+    "user_key_or_id": {
       "type": "string",
-      "required": true
-    },
-    "email": {
-      "type": "email",
-      "required": true
-    },
-    "SEO": {
-      "type": "component",
-      "repeatable": false,
-      "component": "common.seo"
+      "required": false
     }
   }
 }

--- a/src/api/markket/content-types/markket/schema.json
+++ b/src/api/markket/content-types/markket/schema.json
@@ -1,0 +1,33 @@
+{
+  "kind": "collectionType",
+  "collectionName": "markkets",
+  "info": {
+    "singularName": "markket",
+    "pluralName": "markkets",
+    "displayName": "markket",
+    "description": "Instance of a markket - usage records"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "Key": {
+      "type": "string",
+      "required": true
+    },
+    "Content": {
+      "type": "string",
+      "required": true
+    },
+    "email": {
+      "type": "email",
+      "required": true
+    },
+    "SEO": {
+      "type": "component",
+      "repeatable": false,
+      "component": "common.seo"
+    }
+  }
+}

--- a/src/api/markket/controllers/markket.ts
+++ b/src/api/markket/controllers/markket.ts
@@ -1,0 +1,30 @@
+/**
+ * markket controller
+ */
+import { version } from '../../../../package.json';
+const { createCoreController } = require('@strapi/strapi').factories;
+const modelId = "api::markket.markket";
+
+const NODE_ENV = process.env.NODE_ENV || 'development';
+const STRIPE_PUBLIC_KEY = process.env.STRIPE_PUBLIC_KEY || 'n/a';
+const SENDGRID_REPLY_TO_EMAIL = process.env.SENDGRID_REPLY_TO_EMAIL || 'n/a';
+
+module.exports = createCoreController(modelId, ({ /**strapi */ }) => ({
+
+  async about(ctx: any) {
+    console.info('markket.get');
+    // await strapi.service(modelId).find(ctx.request.body)
+
+    ctx.send({
+      message: 'This is the about endpoint',
+      data: {
+        info: 'Markket.place is an international commercial community',
+        version,
+        NODE_ENV,
+        STRIPE_PUBLIC_KEY,
+        SENDGRID_REPLY_TO_EMAIL,
+      },
+    });
+  },
+}));
+

--- a/src/api/markket/controllers/markket.ts
+++ b/src/api/markket/controllers/markket.ts
@@ -9,12 +9,9 @@ const NODE_ENV = process.env.NODE_ENV || 'development';
 const STRIPE_PUBLIC_KEY = process.env.STRIPE_PUBLIC_KEY || 'n/a';
 const SENDGRID_REPLY_TO_EMAIL = process.env.SENDGRID_REPLY_TO_EMAIL || 'n/a';
 
-module.exports = createCoreController(modelId, ({ /**strapi */ }) => ({
-
+module.exports = createCoreController(modelId, ({ strapi }) => ({
   async about(ctx: any) {
     console.info('markket.get');
-    // await strapi.service(modelId).find(ctx.request.body)
-
     ctx.send({
       message: 'This is the about endpoint',
       data: {
@@ -26,5 +23,23 @@ module.exports = createCoreController(modelId, ({ /**strapi */ }) => ({
       },
     });
   },
+  async create(ctx: any) {
+    console.info('markket.create');
+    await strapi.service(modelId).create({
+      locale: 'en',
+      data: {
+        Key: "markket.create",
+        Content: ctx.request.body,
+        user_key_or_id: "", // @TODO: Review authorization, token or related user
+      }
+    });
+    // @TODO: send notification emails, perform STRIPE actions, etc, here
+    ctx.send({
+      message: 'This is the create endpoint',
+      data: {
+        info: 'Markket.place is an international commercial community',
+        version,
+      },
+    });
+  }
 }));
-

--- a/src/api/markket/routes/markket.ts
+++ b/src/api/markket/routes/markket.ts
@@ -13,5 +13,14 @@ module.exports = {
         middlewares: [],
       },
     },
+    {
+      method: 'POST',
+      path: '/markket',
+      handler: 'markket.create',
+      config: {
+        policies: [],
+        middlewares: [],
+      },
+    }
   ],
 };

--- a/src/api/markket/routes/markket.ts
+++ b/src/api/markket/routes/markket.ts
@@ -1,0 +1,17 @@
+/**
+ * Markket router
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/markket',
+      handler: 'markket.about',
+      config: {
+        policies: [],
+        middlewares: [],
+      },
+    },
+  ],
+};

--- a/src/api/markket/services/markket.ts
+++ b/src/api/markket/services/markket.ts
@@ -1,0 +1,7 @@
+/**
+ * markket service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::markket.markket');

--- a/src/components/common/seo.json
+++ b/src/components/common/seo.json
@@ -30,6 +30,9 @@
     "metaUrl": {
       "type": "string"
     },
+    "metaDate": {
+      "type": "datetime"
+    },
     "metaAuthor": {
       "type": "string"
     },

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -137,6 +137,7 @@ export interface CommonSeo extends Struct.ComponentSchema {
     excludeFromSearch: Schema.Attribute.Boolean &
       Schema.Attribute.DefaultTo<false>;
     metaAuthor: Schema.Attribute.String;
+    metaDate: Schema.Attribute.DateTime;
     metaDescription: Schema.Attribute.String;
     metaKeywords: Schema.Attribute.String;
     metaTitle: Schema.Attribute.String;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -520,7 +520,7 @@ export interface ApiMarkketMarkket extends Struct.CollectionTypeSchema {
   collectionName: 'markkets';
   info: {
     description: 'Instance of a markket - usage records';
-    displayName: 'markket';
+    displayName: 'Markket';
     pluralName: 'markkets';
     singularName: 'markket';
   };
@@ -528,11 +528,10 @@ export interface ApiMarkketMarkket extends Struct.CollectionTypeSchema {
     draftAndPublish: true;
   };
   attributes: {
-    Content: Schema.Attribute.String & Schema.Attribute.Required;
+    Content: Schema.Attribute.JSON & Schema.Attribute.Required;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
-    email: Schema.Attribute.Email & Schema.Attribute.Required;
     Key: Schema.Attribute.String & Schema.Attribute.Required;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
@@ -541,10 +540,10 @@ export interface ApiMarkketMarkket extends Struct.CollectionTypeSchema {
     > &
       Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
-    SEO: Schema.Attribute.Component<'common.seo', false>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+    user_key_or_id: Schema.Attribute.String;
   };
 }
 

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -516,6 +516,38 @@ export interface ApiInboxInbox extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiMarkketMarkket extends Struct.CollectionTypeSchema {
+  collectionName: 'markkets';
+  info: {
+    description: 'Instance of a markket - usage records';
+    displayName: 'markket';
+    pluralName: 'markkets';
+    singularName: 'markket';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    Content: Schema.Attribute.String & Schema.Attribute.Required;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    email: Schema.Attribute.Email & Schema.Attribute.Required;
+    Key: Schema.Attribute.String & Schema.Attribute.Required;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::markket.markket'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    SEO: Schema.Attribute.Component<'common.seo', false>;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiOrderOrder extends Struct.CollectionTypeSchema {
   collectionName: 'orders';
   info: {
@@ -1473,6 +1505,7 @@ declare module '@strapi/strapi' {
       'api::category.category': ApiCategoryCategory;
       'api::extension.extension': ApiExtensionExtension;
       'api::inbox.inbox': ApiInboxInbox;
+      'api::markket.markket': ApiMarkketMarkket;
       'api::order.order': ApiOrderOrder;
       'api::page.page': ApiPagePage;
       'api::product.product': ApiProductProduct;


### PR DESCRIPTION

This pull request introduces a new `markket` feature in the API, including schema, controller, routes, and service setup. The most important changes are summarized below:

### Schema Definition:

* [`src/api/markket/content-types/markket/schema.json`](diffhunk://#diff-f93097279558b51af56acd20c7bb70c314c604bd341e2166591543e0cd38d19cR1-R33): Added a new schema for the `markket` collection type with attributes such as `Key`, `Content`, `email`, and `SEO`.

### Controller Setup:

* [`src/api/markket/controllers/markket.ts`](diffhunk://#diff-dcdd23c3fc144c6f59f302ea018f969d0f15fed633d9887353c1f7691eea1f83R1-R30): Created a new controller for `markket` with an `about` endpoint that provides information about the `markket` instance and environment variables.

### Routing Configuration:

* [`src/api/markket/routes/markket.ts`](diffhunk://#diff-184bd791c716755a0dfedcc94a737383bbe53cbf9e13c184a1385d28ceeece75R1-R17): Defined a new route for the `markket` endpoint, mapping the GET request to the `about` handler in the controller.

### Service Initialization:

* [`src/api/markket/services/markket.ts`](diffhunk://#diff-2b7e01122e0d461253075baabdf4d37054ca1c81d0379a21e335453609f85821R1-R7): Set up a new core service for the `markket` API using Strapi's factory method.