### PR TITLE
Added new fields to User

### DIFF
--- a/src/api/article/content-types/article/lifecycles.ts
+++ b/src/api/article/content-types/article/lifecycles.ts
@@ -3,7 +3,8 @@ const slugify = (str: string) => {
     .toLowerCase()
     .trim()
     .replace(/ /g, '-')
-    .replace(/[^\w-]+/g, '');
+    .replace(/[^\w-]+/g, '')
+    .replace(/-+/g, '-');
 };
 
 const formatDate = (date: Date) => {

--- a/src/extensions/users-permissions/content-types/user/schema.json
+++ b/src/extensions/users-permissions/content-types/user/schema.json
@@ -79,6 +79,25 @@
       "relation": "oneToMany",
       "target": "api::rsvp.rsvp",
       "mappedBy": "users"
+    },
+    "bio": {
+      "type": "text",
+      "maxLength": 500,
+      "configurable": false
+    },
+    "avatar": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images"
+      ],
+      "configurable": false
+    },
+    "displayName": {
+      "type": "string",
+      "minLength": 2,
+      "configurable": false
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1615,12 +1615,21 @@ export interface PluginUsersPermissionsUser
     draftAndPublish: false;
   };
   attributes: {
+    avatar: Schema.Attribute.Media<'images'>;
+    bio: Schema.Attribute.Text &
+      Schema.Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
     blocked: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
     confirmationToken: Schema.Attribute.String & Schema.Attribute.Private;
     confirmed: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+    displayName: Schema.Attribute.String &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 2;
+      }>;
     email: Schema.Attribute.Email &
       Schema.Attribute.Required &
       Schema.Attribute.SetMinMaxLength<{


### PR DESCRIPTION
This pull request includes changes to the `src/api/article/content-types/article/lifecycles.ts` and `src/extensions/users-permissions/content-types/user/schema.json` files. The changes focus on improving the slugify function and enhancing the user schema.

Improvements to slugify function:

* [`src/api/article/content-types/article/lifecycles.ts`](diffhunk://#diff-f82f5f566853cbdd12c09a167485f4e2309d786f42eb199fc7e8da25c35068a4L6-R7): Modified the `slugify` function to replace consecutive hyphens with a single hyphen. This ensures cleaner and more readable slugs.

Enhancements to user schema:

* [`src/extensions/users-permissions/content-types/user/schema.json`](diffhunk://#diff-7efa6413851f42bd48c561812a8673db294d24779ec708927bf54b3d15f3a743R82-R100): Added new fields to the user schema, including `bio`, `avatar`, and `displayName`, to support additional user information.