### PR TITLE
renamed list to galleries for better syntax

### DIFF
--- a/src/api/gallery/content-types/gallery/schema.json
+++ b/src/api/gallery/content-types/gallery/schema.json
@@ -1,10 +1,10 @@
 {
   "kind": "collectionType",
-  "collectionName": "lists",
+  "collectionName": "galleries",
   "info": {
-    "singularName": "list",
-    "pluralName": "lists",
-    "displayName": "List",
+    "singularName": "gallery",
+    "pluralName": "galleries",
+    "displayName": "Galleries",
     "description": "Curated lists of items for easy galleries"
   },
   "options": {
@@ -64,7 +64,7 @@
       "type": "relation",
       "relation": "manyToMany",
       "target": "api::store.store",
-      "inversedBy": "lists"
+      "inversedBy": "galleries"
     },
     "displayType": {
       "type": "enumeration",
@@ -78,14 +78,14 @@
     "items": {
       "type": "relation",
       "relation": "manyToMany",
-      "target": "api::list.list-item",
-      "inversedBy": "lists"
+      "target": "api::gallery.item",
+      "inversedBy": "galleries"
     },
     "pages": {
       "type": "relation",
       "relation": "manyToMany",
       "target": "api::page.page",
-      "inversedBy": "lists"
+      "inversedBy": "galleries"
     }
   }
 }

--- a/src/api/gallery/content-types/item/schema.json
+++ b/src/api/gallery/content-types/item/schema.json
@@ -1,11 +1,11 @@
 {
   "kind": "collectionType",
-  "collectionName": "list_items",
+  "collectionName": "items",
   "info": {
-    "singularName": "list-item",
-    "pluralName": "list-items",
-    "displayName": "List Item",
-    "description": "Items that can be added to lists"
+    "singularName": "item",
+    "pluralName": "items",
+    "displayName": "Gallery Items",
+    "description": "Items that can be added to galleries"
   },
   "options": {
     "draftAndPublish": true
@@ -68,10 +68,10 @@
         }
       }
     },
-    "lists": {
+    "galleries": {
       "type": "relation",
       "relation": "manyToMany",
-      "target": "api::list.list",
+      "target": "api::gallery.gallery",
       "inversedBy": "items"
     }
   }

--- a/src/api/gallery/controllers/gallery.ts
+++ b/src/api/gallery/controllers/gallery.ts
@@ -4,4 +4,4 @@
 
 import { factories } from '@strapi/strapi'
 
-export default factories.createCoreController('api::list.list');
+export default factories.createCoreController('api::gallery.gallery');

--- a/src/api/gallery/controllers/item.ts
+++ b/src/api/gallery/controllers/item.ts
@@ -1,0 +1,7 @@
+/**
+ *  controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::gallery.item');

--- a/src/api/gallery/routes/gallery.ts
+++ b/src/api/gallery/routes/gallery.ts
@@ -1,0 +1,7 @@
+/**
+ * gallery router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::gallery.gallery');

--- a/src/api/gallery/routes/item.ts
+++ b/src/api/gallery/routes/item.ts
@@ -1,0 +1,7 @@
+/**
+ *  router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::gallery.item');

--- a/src/api/gallery/services/gallery.ts
+++ b/src/api/gallery/services/gallery.ts
@@ -1,0 +1,7 @@
+/**
+ * gallery service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::gallery.gallery');

--- a/src/api/gallery/services/item.ts
+++ b/src/api/gallery/services/item.ts
@@ -1,0 +1,7 @@
+/**
+ *  service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::gallery.item');

--- a/src/api/list/controllers/list-item.ts
+++ b/src/api/list/controllers/list-item.ts
@@ -1,7 +1,0 @@
-/**
- *  controller
- */
-
-import { factories } from '@strapi/strapi'
-
-export default factories.createCoreController('api::list.list-item');

--- a/src/api/list/routes/list-item.ts
+++ b/src/api/list/routes/list-item.ts
@@ -1,7 +1,0 @@
-/**
- *  router
- */
-
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreRouter('api::list.list-item');

--- a/src/api/list/routes/list.ts
+++ b/src/api/list/routes/list.ts
@@ -1,7 +1,0 @@
-/**
- * list router
- */
-
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreRouter('api::list.list');

--- a/src/api/list/services/list-item.ts
+++ b/src/api/list/services/list-item.ts
@@ -1,7 +1,0 @@
-/**
- *  service
- */
-
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreService('api::list.list-item');

--- a/src/api/list/services/list.ts
+++ b/src/api/list/services/list.ts
@@ -1,7 +1,0 @@
-/**
- * list service
- */
-
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreService('api::list.list');

--- a/src/api/page/content-types/page/schema.json
+++ b/src/api/page/content-types/page/schema.json
@@ -47,10 +47,10 @@
       "target": "api::store.store",
       "inversedBy": "pages"
     },
-    "lists": {
+    "galleries": {
       "type": "relation",
       "relation": "manyToMany",
-      "target": "api::list.list",
+      "target": "api::gallery.gallery",
       "inversedBy": "pages"
     },
     "creator": {

--- a/src/api/store/content-types/store/schema.json
+++ b/src/api/store/content-types/store/schema.json
@@ -201,10 +201,10 @@
       "target": "plugin::users-permissions.user",
       "inversedBy": "stores"
     },
-    "lists": {
+    "galleries": {
       "type": "relation",
       "relation": "manyToMany",
-      "target": "api::list.list",
+      "target": "api::gallery.gallery",
       "mappedBy": "stores"
     },
     "subscribers": {

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -597,6 +597,131 @@ export interface ApiExtensionExtension extends Struct.SingleTypeSchema {
   };
 }
 
+export interface ApiGalleryGallery extends Struct.CollectionTypeSchema {
+  collectionName: 'galleries';
+  info: {
+    description: 'Curated lists of items for easy galleries';
+    displayName: 'Galleries';
+    pluralName: 'galleries';
+    singularName: 'gallery';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
+  attributes: {
+    cover: Schema.Attribute.Media<'images'> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    description: Schema.Attribute.RichText &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    displayType: Schema.Attribute.Enumeration<['grid', 'list', 'carousel']> &
+      Schema.Attribute.DefaultTo<'grid'>;
+    items: Schema.Attribute.Relation<'manyToMany', 'api::gallery.item'>;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::gallery.gallery'
+    >;
+    pages: Schema.Attribute.Relation<'manyToMany', 'api::page.page'>;
+    publishedAt: Schema.Attribute.DateTime;
+    SEO: Schema.Attribute.Component<'common.seo', false> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    slug: Schema.Attribute.String & Schema.Attribute.Required;
+    stores: Schema.Attribute.Relation<'manyToMany', 'api::store.store'>;
+    title: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiGalleryItem extends Struct.CollectionTypeSchema {
+  collectionName: 'items';
+  info: {
+    description: 'Items that can be added to galleries';
+    displayName: 'Gallery Items';
+    pluralName: 'items';
+    singularName: 'item';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
+  attributes: {
+    bio: Schema.Attribute.RichText &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    galleries: Schema.Attribute.Relation<'manyToMany', 'api::gallery.gallery'>;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<'oneToMany', 'api::gallery.item'>;
+    media: Schema.Attribute.Media<'images' | 'files' | 'videos', true> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    publishedAt: Schema.Attribute.DateTime;
+    SEO: Schema.Attribute.Component<'common.seo', false> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    slug: Schema.Attribute.String & Schema.Attribute.Required;
+    title: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    URLS: Schema.Attribute.Component<'common.urls', true> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+  };
+}
+
 export interface ApiInboxInbox extends Struct.CollectionTypeSchema {
   collectionName: 'inboxes';
   info: {
@@ -630,131 +755,6 @@ export interface ApiInboxInbox extends Struct.CollectionTypeSchema {
       'oneToOne',
       'plugin::users-permissions.user'
     >;
-  };
-}
-
-export interface ApiListList extends Struct.CollectionTypeSchema {
-  collectionName: 'lists';
-  info: {
-    description: 'Curated lists of items for easy galleries';
-    displayName: 'List';
-    pluralName: 'lists';
-    singularName: 'list';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  pluginOptions: {
-    i18n: {
-      localized: true;
-    };
-  };
-  attributes: {
-    cover: Schema.Attribute.Media<'images'> &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
-    createdAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
-    description: Schema.Attribute.RichText &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
-    displayType: Schema.Attribute.Enumeration<['grid', 'list', 'carousel']> &
-      Schema.Attribute.DefaultTo<'grid'>;
-    items: Schema.Attribute.Relation<'manyToMany', 'api::list.list-item'>;
-    locale: Schema.Attribute.String;
-    localizations: Schema.Attribute.Relation<'oneToMany', 'api::list.list'>;
-    pages: Schema.Attribute.Relation<'manyToMany', 'api::page.page'>;
-    publishedAt: Schema.Attribute.DateTime;
-    SEO: Schema.Attribute.Component<'common.seo', false> &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
-    slug: Schema.Attribute.String & Schema.Attribute.Required;
-    stores: Schema.Attribute.Relation<'manyToMany', 'api::store.store'>;
-    title: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
-    updatedAt: Schema.Attribute.DateTime;
-    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
-  };
-}
-
-export interface ApiListListItem extends Struct.CollectionTypeSchema {
-  collectionName: 'list_items';
-  info: {
-    description: 'Items that can be added to lists';
-    displayName: 'List Item';
-    pluralName: 'list-items';
-    singularName: 'list-item';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  pluginOptions: {
-    i18n: {
-      localized: true;
-    };
-  };
-  attributes: {
-    bio: Schema.Attribute.RichText &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
-    createdAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
-    lists: Schema.Attribute.Relation<'manyToMany', 'api::list.list'>;
-    locale: Schema.Attribute.String;
-    localizations: Schema.Attribute.Relation<
-      'oneToMany',
-      'api::list.list-item'
-    >;
-    media: Schema.Attribute.Media<'images' | 'files' | 'videos', true> &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
-    publishedAt: Schema.Attribute.DateTime;
-    SEO: Schema.Attribute.Component<'common.seo', false> &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
-    slug: Schema.Attribute.String & Schema.Attribute.Required;
-    title: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
-    updatedAt: Schema.Attribute.DateTime;
-    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
-    URLS: Schema.Attribute.Component<'common.urls', true> &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
   };
 }
 
@@ -864,7 +864,7 @@ export interface ApiPagePage extends Struct.CollectionTypeSchema {
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
     creator: Schema.Attribute.Relation<'oneToOne', 'admin::user'>;
-    lists: Schema.Attribute.Relation<'manyToMany', 'api::list.list'>;
+    galleries: Schema.Attribute.Relation<'manyToMany', 'api::gallery.gallery'>;
     locale: Schema.Attribute.String;
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::page.page'>;
     menuOrder: Schema.Attribute.Integer &
@@ -1181,7 +1181,7 @@ export interface ApiStoreStore extends Struct.CollectionTypeSchema {
           localized: true;
         };
       }>;
-    lists: Schema.Attribute.Relation<'manyToMany', 'api::list.list'>;
+    galleries: Schema.Attribute.Relation<'manyToMany', 'api::gallery.gallery'>;
     locale: Schema.Attribute.String;
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::store.store'>;
     Logo: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
@@ -1815,9 +1815,9 @@ declare module '@strapi/strapi' {
       'api::category.category': ApiCategoryCategory;
       'api::event.event': ApiEventEvent;
       'api::extension.extension': ApiExtensionExtension;
+      'api::gallery.gallery': ApiGalleryGallery;
+      'api::gallery.item': ApiGalleryItem;
       'api::inbox.inbox': ApiInboxInbox;
-      'api::list.list': ApiListList;
-      'api::list.list-item': ApiListListItem;
       'api::markket.markket': ApiMarkketMarkket;
       'api::order.order': ApiOrderOrder;
       'api::page.page': ApiPagePage;


### PR DESCRIPTION
This pull request includes a comprehensive renaming and restructuring of the content types and related files from "list" to "gallery" within the `src/api` directory. The changes ensure consistency across the schema, controllers, routes, and services.

Key changes include:

### Renaming and restructuring content types:

* [`src/api/gallery/content-types/gallery/schema.json`](diffhunk://#diff-a0ffe77e4c46fffd49a9b5d976b75ee186b6dfa4836f4d4c454b19e6a23c6519L3-R7): Renamed from `src/api/list/content-types/list/schema.json` and updated collection names and relations from "lists" to "galleries". [[1]](diffhunk://#diff-a0ffe77e4c46fffd49a9b5d976b75ee186b6dfa4836f4d4c454b19e6a23c6519L3-R7) [[2]](diffhunk://#diff-a0ffe77e4c46fffd49a9b5d976b75ee186b6dfa4836f4d4c454b19e6a23c6519L67-R67) [[3]](diffhunk://#diff-a0ffe77e4c46fffd49a9b5d976b75ee186b6dfa4836f4d4c454b19e6a23c6519L81-R88)
* [`src/api/gallery/content-types/item/schema.json`](diffhunk://#diff-cee9be92d252fe73b1a9a4eac01f16398d34eb3cfffc584a2030db6753a308adL3-R8): Renamed from `src/api/list/content-types/list-item/schema.json` and updated collection names and relations from "list-items" to "items". [[1]](diffhunk://#diff-cee9be92d252fe73b1a9a4eac01f16398d34eb3cfffc584a2030db6753a308adL3-R8) [[2]](diffhunk://#diff-cee9be92d252fe73b1a9a4eac01f16398d34eb3cfffc584a2030db6753a308adL71-R74)

### Updating controllers:

* [`src/api/gallery/controllers/gallery.ts`](diffhunk://#diff-b1e183565909be433f5c970b0fe8c73357492fee3fcf6355a3b050404e7351c6L7-R7): Renamed from `src/api/list/controllers/list.ts` and updated the controller to use `gallery`.
* [`src/api/gallery/controllers/item.ts`](diffhunk://#diff-08192f576680d371bc07750a61a610d6aadf625b34c406407b69ad85ca0722aaR1-R7): Added a new controller for `gallery.item`.

### Updating routes:

* [`src/api/gallery/routes/gallery.ts`](diffhunk://#diff-7b00951eff6138e0df9cca3c42fb4ae653c0f6bdac0a508e00fe89a9d8d654d5R1-R7): Added a new router for `gallery`.
* [`src/api/gallery/routes/item.ts`](diffhunk://#diff-d6c3962037dd4b043a7a8b6e17f847e8cbbdf959d5acd0b915ebabc9ede4896cR1-R7): Added a new router for `gallery.item`.

### Updating services:

* [`src/api/gallery/services/gallery.ts`](diffhunk://#diff-361b32a734e512276fbc9bf1ac2943c1f00e4b15803cab5c6d15d463aec903b5R1-R7): Added a new service for `gallery`.
* [`src/api/gallery/services/item.ts`](diffhunk://#diff-a80ee8c53450c7697a17efc4c6f61be23492477a5b9a68d54d4c0ffc239f7ea1R1-R7): Added a new service for `gallery.item`.

### Removing old list-related files:

* Removed old list-related controllers, routes, and services files. [[1]](diffhunk://#diff-a0b7f67b33004823dc04413efd307e518bc58031ea2dfaf8c7098866010f682eL1-L7) [[2]](diffhunk://#diff-b6355b463f20f1d92282f305e3c810a1fce047636652db6de9b89488db6fcdb0L1-L7) [[3]](diffhunk://#diff-5f40995cf79f22ee64798b49d302e3c7bd25b8e676323268fd1e9718dfe64481L1-L7) [[4]](diffhunk://#diff-43143600f36301e52c89a513c527cedad080c78e103a1b07ecfbafa124abe565L1-L7) [[5]](diffhunk://#diff-111916d6cc3d6180c544d59a65073c2e562fb574a170cd1b7aea7ca07a7e077bL1-L7)

### Updating references in other schemas:

* Updated references from "lists" to "galleries" in `src/api/page/content-types/page/schema.json` and `src/api/store/content-types/store/schema.json`. [[1]](diffhunk://#diff-ac7bdda45d671124d587e256105979c962739b4d5cd6fb2cb60e1949efd06ca9L50-R53) [[2]](diffhunk://#diff-53a7343449f401cdff2eb01e3f7a37e935f5a58b7ffcab0bacc83c0d621fe1bfL204-R207)