### PR TITLE
Created content type albums 

### DIFF
--- a/src/api/album/content-types/album/schema.json
+++ b/src/api/album/content-types/album/schema.json
@@ -29,6 +29,12 @@
       "relation": "manyToMany",
       "target": "api::page.page",
       "label": "Pages"
+    },
+    "store": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::store.store",
+      "inversedBy": "albums"
     }
   }
 }

--- a/src/api/album/content-types/album/schema.json
+++ b/src/api/album/content-types/album/schema.json
@@ -1,0 +1,34 @@
+{
+  "kind": "collectionType",
+  "collectionName": "albums",
+  "info": {
+    "singularName": "album",
+    "pluralName": "albums",
+    "displayName": "Album"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "tracks": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::album.track",
+      "label": "Tracks"
+    },
+    "pages": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::page.page",
+      "label": "Pages"
+    }
+  }
+}

--- a/src/api/album/content-types/album/schema.json
+++ b/src/api/album/content-types/album/schema.json
@@ -15,8 +15,33 @@
     }
   },
   "attributes": {
-    "title": {
+    "slug": {
       "type": "string"
+    },
+    "title": {
+      "type": "string",
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "description": {
+      "type": "blocks",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "SEO": {
+      "type": "component",
+      "component": "common.seo"
+    },
+    "cover": {
+      "type": "media",
+      "multiple": false
     },
     "tracks": {
       "type": "relation",

--- a/src/api/album/content-types/track/schema.json
+++ b/src/api/album/content-types/track/schema.json
@@ -15,19 +15,40 @@
     }
   },
   "attributes": {
+    "slug": {
+      "type": "string"
+    },
     "title": {
       "type": "string",
+      "required": true,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       }
     },
+    "description": {
+      "type": "blocks",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "SEO": {
+      "type": "component",
+      "component": "common.seo"
+    },
+    "media": {
+      "type": "media",
+      "multiple": true
+    },
     "albums": {
       "type": "relation",
       "relation": "manyToMany",
       "target": "api::album.album",
-      "label": "Albums"
+      "label": "Albums",
+      "inversedBy": "tracks"
     }
   }
 }

--- a/src/api/album/content-types/track/schema.json
+++ b/src/api/album/content-types/track/schema.json
@@ -1,0 +1,33 @@
+{
+  "kind": "collectionType",
+  "collectionName": "track",
+  "info": {
+    "singularName": "track",
+    "pluralName": "tracks",
+    "displayName": "Album Track"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "albums": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::album.album",
+      "label": "Albums"
+    }
+  }
+}

--- a/src/api/album/controllers/album.ts
+++ b/src/api/album/controllers/album.ts
@@ -1,0 +1,7 @@
+/**
+ * album controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::album.album');

--- a/src/api/album/controllers/track.ts
+++ b/src/api/album/controllers/track.ts
@@ -1,0 +1,7 @@
+/**
+ *  controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::album.track');

--- a/src/api/album/routes/album.ts
+++ b/src/api/album/routes/album.ts
@@ -1,0 +1,7 @@
+/**
+ * album router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::album.album');

--- a/src/api/album/routes/track.ts
+++ b/src/api/album/routes/track.ts
@@ -1,0 +1,7 @@
+/**
+ *  router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::album.track');

--- a/src/api/album/services/album.ts
+++ b/src/api/album/services/album.ts
@@ -1,0 +1,7 @@
+/**
+ * album service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::album.album');

--- a/src/api/album/services/track.ts
+++ b/src/api/album/services/track.ts
@@ -1,0 +1,7 @@
+/**
+ *  service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::album.track');

--- a/src/api/page/content-types/page/schema.json
+++ b/src/api/page/content-types/page/schema.json
@@ -47,6 +47,12 @@
       "target": "api::store.store",
       "inversedBy": "pages"
     },
+    "albums": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::album.album",
+      "label": "Albums"
+    },
     "creator": {
       "type": "relation",
       "relation": "oneToOne",

--- a/src/api/store/content-types/store/lifecycle.ts
+++ b/src/api/store/content-types/store/lifecycle.ts
@@ -37,7 +37,21 @@
 //     if (!user) {
 //       throw new Error('User not authenticated');
 //     }
+// in strapi v5 we must use the documents api instead of the entityService
+// strapi.documents.use((ctx, next) => {
+//   if (ctx.uid !== "api::my-content-type.my-content-type") {
+//     return next();
+//   }
 
+//   if (ctx.action === 'findOne') {
+//     // customization
+//     ctx.params.filters = { ...params.filters, deletedAt: { $notNull: true } }
+//     const res = await next();
+//     // do something with the response if you want
+//     return res;
+//   }
+//   return next();
+// });
 //     try {
 //       // Check store count
 //       const { count: userStores } = await strapi.entityService.count(MODEL_ID, {

--- a/src/api/store/content-types/store/schema.json
+++ b/src/api/store/content-types/store/schema.json
@@ -150,6 +150,14 @@
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::page.page",
+      "label": "Pages",
+      "mappedBy": "store"
+    },
+    "albums": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::album.album",
+      "label": "Albums",
       "mappedBy": "store"
     },
     "URLS": {

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -369,6 +369,72 @@ export interface AdminUser extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiAlbumAlbum extends Struct.CollectionTypeSchema {
+  collectionName: 'albums';
+  info: {
+    displayName: 'Album';
+    pluralName: 'albums';
+    singularName: 'album';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<'oneToMany', 'api::album.album'>;
+    pages: Schema.Attribute.Relation<'manyToMany', 'api::page.page'>;
+    publishedAt: Schema.Attribute.DateTime;
+    title: Schema.Attribute.String;
+    tracks: Schema.Attribute.Relation<'manyToMany', 'api::album.track'>;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiAlbumTrack extends Struct.CollectionTypeSchema {
+  collectionName: 'track';
+  info: {
+    displayName: 'Album Track';
+    pluralName: 'tracks';
+    singularName: 'track';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
+  attributes: {
+    albums: Schema.Attribute.Relation<'manyToMany', 'api::album.album'>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String;
+    localizations: Schema.Attribute.Relation<'oneToMany', 'api::album.track'>;
+    publishedAt: Schema.Attribute.DateTime;
+    title: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiArticleArticle extends Struct.CollectionTypeSchema {
   collectionName: 'articles';
   info: {
@@ -729,6 +795,7 @@ export interface ApiPagePage extends Struct.CollectionTypeSchema {
           localized: true;
         };
       }>;
+    albums: Schema.Attribute.Relation<'manyToMany', 'api::album.album'>;
     Content: Schema.Attribute.Blocks &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
@@ -1684,6 +1751,8 @@ declare module '@strapi/strapi' {
       'admin::transfer-token': AdminTransferToken;
       'admin::transfer-token-permission': AdminTransferTokenPermission;
       'admin::user': AdminUser;
+      'api::album.album': ApiAlbumAlbum;
+      'api::album.track': ApiAlbumTrack;
       'api::article.article': ApiArticleArticle;
       'api::category.category': ApiCategoryCategory;
       'api::event.event': ApiEventEvent;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -392,6 +392,7 @@ export interface ApiAlbumAlbum extends Struct.CollectionTypeSchema {
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::album.album'>;
     pages: Schema.Attribute.Relation<'manyToMany', 'api::page.page'>;
     publishedAt: Schema.Attribute.DateTime;
+    store: Schema.Attribute.Relation<'manyToOne', 'api::store.store'>;
     title: Schema.Attribute.String;
     tracks: Schema.Attribute.Relation<'manyToMany', 'api::album.track'>;
     updatedAt: Schema.Attribute.DateTime;
@@ -1095,6 +1096,7 @@ export interface ApiStoreStore extends Struct.CollectionTypeSchema {
         };
       }>;
     admin_users: Schema.Attribute.Relation<'oneToMany', 'admin::user'>;
+    albums: Schema.Attribute.Relation<'oneToMany', 'api::album.album'>;
     articles: Schema.Attribute.Relation<'oneToMany', 'api::article.article'>;
     categories: Schema.Attribute.Relation<
       'oneToMany',

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -385,15 +385,30 @@ export interface ApiAlbumAlbum extends Struct.CollectionTypeSchema {
     };
   };
   attributes: {
+    cover: Schema.Attribute.Media;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+    description: Schema.Attribute.Blocks &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     locale: Schema.Attribute.String;
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::album.album'>;
     pages: Schema.Attribute.Relation<'manyToMany', 'api::page.page'>;
     publishedAt: Schema.Attribute.DateTime;
+    SEO: Schema.Attribute.Component<'common.seo', false>;
+    slug: Schema.Attribute.String;
     store: Schema.Attribute.Relation<'manyToOne', 'api::store.store'>;
-    title: Schema.Attribute.String;
+    title: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     tracks: Schema.Attribute.Relation<'manyToMany', 'api::album.track'>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
@@ -421,10 +436,20 @@ export interface ApiAlbumTrack extends Struct.CollectionTypeSchema {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+    description: Schema.Attribute.Blocks &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     locale: Schema.Attribute.String;
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::album.track'>;
+    media: Schema.Attribute.Media<undefined, true>;
     publishedAt: Schema.Attribute.DateTime;
+    SEO: Schema.Attribute.Component<'common.seo', false>;
+    slug: Schema.Attribute.String;
     title: Schema.Attribute.String &
+      Schema.Attribute.Required &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true;


### PR DESCRIPTION
This pull request includes the addition of new content types for albums and tracks, as well as updates to existing schemas and the creation of controllers, routers, and services for these new content types. The most important changes include the creation of schemas for albums and tracks, updates to the page and store schemas to include relationships with albums, and the addition of controllers, routers, and services for the new content types.

Creation of new content types:

* [`src/api/album/content-types/album/schema.json`](diffhunk://#diff-3291670e38876d87fdb1a7ce22a23524ea030e81862bb689514ab9c74245b08fR1-R65): Added schema for the `album` content type with attributes such as `slug`, `title`, `description`, `SEO`, `cover`, `tracks`, `pages`, and `store`.
* [`src/api/album/content-types/track/schema.json`](diffhunk://#diff-97790a286ff786cb2bbe29eecabc9720b79d91c6371990987c276c94037485aeR1-R54): Added schema for the `track` content type with attributes such as `slug`, `title`, `description`, `SEO`, `media`, and `albums`.

Updates to existing schemas:

* [`src/api/page/content-types/page/schema.json`](diffhunk://#diff-ac7bdda45d671124d587e256105979c962739b4d5cd6fb2cb60e1949efd06ca9R50-R55): Updated the `page` schema to include a many-to-many relationship with the `album` content type.
* [`src/api/store/content-types/store/schema.json`](diffhunk://#diff-53a7343449f401cdff2eb01e3f7a37e935f5a58b7ffcab0bacc83c0d621fe1bfR153-R160): Updated the `store` schema to include a one-to-many relationship with the `album` content type.

Addition of controllers, routers, and services:

* [`src/api/album/controllers/album.ts`](diffhunk://#diff-c72d03173ef34d28a4824e1bfc61f54d59665e99ac260b8cc05943fe60b02869R1-R7): Created a controller for the `album` content type using Strapi factories.
* [`src/api/album/controllers/track.ts`](diffhunk://#diff-3a5046642193b5feebc421dffcfc7ae88488c37baeebff30978b96cc87858c94R1-R7): Created a controller for the `track` content type using Strapi factories.
* [`src/api/album/routes/album.ts`](diffhunk://#diff-009a03ca85f5188b1f3f848aed400651757caf6fad62b4d5b19003cc9480a88fR1-R7): Created a router for the `album` content type using Strapi factories.
* [`src/api/album/routes/track.ts`](diffhunk://#diff-b5f7a7ad992828c40a837c2c3cc5f35ebef7dfa2129eb52b0eeeeccc1d625437R1-R7): Created a router for the `track` content type using Strapi factories.
* [`src/api/album/services/album.ts`](diffhunk://#diff-1b89c880399f59485bfc5d3a7fb3739410e4037ae48fd42e2efaae51a94636c9R1-R7): Created a service for the `album` content type using Strapi factories.
* [`src/api/album/services/track.ts`](diffhunk://#diff-99b5ebe53b45b2cf0d3f5e660c31a900e86380d052c30324a730b86fd4238587R1-R7): Created a service for the `track` content type using Strapi factories.This pull request introduces a new album and track management feature to the API. It includes the creation of schemas, controllers, routes, and services for albums and tracks, as well as updates to existing schemas to establish relationships with albums.

### New album and track management feature:

* [`src/api/album/content-types/album/schema.json`](diffhunk://#diff-3291670e38876d87fdb1a7ce22a23524ea030e81862bb689514ab9c74245b08fR1-R40): Added a new schema for the `album` collection type with attributes for title, tracks, pages, and store relationships.
* [`src/api/album/content-types/track/schema.json`](diffhunk://#diff-97790a286ff786cb2bbe29eecabc9720b79d91c6371990987c276c94037485aeR1-R33): Added a new schema for the `track` collection type with attributes for title and albums relationships.

### Controllers, routes, and services:

* [`src/api/album/controllers/album.ts`](diffhunk://#diff-c72d03173ef34d28a4824e1bfc61f54d59665e99ac260b8cc05943fe60b02869R1-R7): Created a core controller for the `album` collection type.
* [`src/api/album/controllers/track.ts`](diffhunk://#diff-3a5046642193b5feebc421dffcfc7ae88488c37baeebff30978b96cc87858c94R1-R7): Created a core controller for the `track` collection type.
* [`src/api/album/routes/album.ts`](diffhunk://#diff-009a03ca85f5188b1f3f848aed400651757caf6fad62b4d5b19003cc9480a88fR1-R7): Created a core router for the `album` collection type.
* [`src/api/album/routes/track.ts`](diffhunk://#diff-b5f7a7ad992828c40a837c2c3cc5f35ebef7dfa2129eb52b0eeeeccc1d625437R1-R7): Created a core router for the `track` collection type.
* [`src/api/album/services/album.ts`](diffhunk://#diff-1b89c880399f59485bfc5d3a7fb3739410e4037ae48fd42e2efaae51a94636c9R1-R7): Created a core service for the `album` collection type.
* [`src/api/album/services/track.ts`](diffhunk://#diff-99b5ebe53b45b2cf0d3f5e660c31a900e86380d052c30324a730b86fd4238587R1-R7): Created a core service for the `track` collection type.

### Schema updates for relationships:

* [`src/api/page/content-types/page/schema.json`](diffhunk://#diff-ac7bdda45d671124d587e256105979c962739b4d5cd6fb2cb60e1949efd06ca9R50-R55): Added a many-to-many relationship with the `album` collection type.
* [`src/api/store/content-types/store/schema.json`](diffhunk://#diff-53a7343449f401cdff2eb01e3f7a37e935f5a58b7ffcab0bacc83c0d621fe1bfR153-R160): Added a one-to-many relationship with the `album` collection type.