### PR TITLE
added URLS to album.tracks

### DIFF
--- a/src/api/album/content-types/track/schema.json
+++ b/src/api/album/content-types/track/schema.json
@@ -39,6 +39,17 @@
       "type": "component",
       "component": "common.seo"
     },
+    "urls": {
+      "displayName": "Urls",
+      "type": "component",
+      "repeatable": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "common.urls"
+    },
     "media": {
       "type": "media",
       "multiple": true

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -458,6 +458,12 @@ export interface ApiAlbumTrack extends Struct.CollectionTypeSchema {
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+    urls: Schema.Attribute.Component<'common.urls', true> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
   };
 }
 


### PR DESCRIPTION
This pull request includes a change to the `src/api/album/content-types/track/schema.json` file, adding a new component for URLs. The change introduces a repeatable `urls` component with localization support.

* Added a new `urls` component with repeatable and localized options to the `schema.json` file.