### PR TITLE
Removed store.albums property in schema

### DIFF
--- a/src/api/album/content-types/album/schema.json
+++ b/src/api/album/content-types/album/schema.json
@@ -58,8 +58,7 @@
     "store": {
       "type": "relation",
       "relation": "manyToOne",
-      "target": "api::store.store",
-      "inversedBy": "albums"
+      "target": "api::store.store"
     }
   }
 }

--- a/src/api/store/content-types/store/schema.json
+++ b/src/api/store/content-types/store/schema.json
@@ -153,13 +153,6 @@
       "label": "Pages",
       "mappedBy": "store"
     },
-    "albums": {
-      "type": "relation",
-      "relation": "oneToMany",
-      "target": "api::album.album",
-      "label": "Albums",
-      "mappedBy": "store"
-    },
     "URLS": {
       "displayName": "URLS",
       "type": "component",

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1127,7 +1127,6 @@ export interface ApiStoreStore extends Struct.CollectionTypeSchema {
         };
       }>;
     admin_users: Schema.Attribute.Relation<'oneToMany', 'admin::user'>;
-    albums: Schema.Attribute.Relation<'oneToMany', 'api::album.album'>;
     articles: Schema.Attribute.Relation<'oneToMany', 'api::article.article'>;
     categories: Schema.Attribute.Relation<
       'oneToMany',


### PR DESCRIPTION
This pull request includes changes to the schema definitions for the `album` and `store` content types to streamline their relationships.

Changes to schema definitions:

* [`src/api/album/content-types/album/schema.json`](diffhunk://#diff-3291670e38876d87fdb1a7ce22a23524ea030e81862bb689514ab9c74245b08fL61-R61): Removed the `inversedBy` property from the `store` relation.
* [`src/api/store/content-types/store/schema.json`](diffhunk://#diff-53a7343449f401cdff2eb01e3f7a37e935f5a58b7ffcab0bacc83c0d621fe1bfL156-L162): Removed the `albums` relation property.