### PR TITLE
Fixed fields in the albums & track dashboard 

### DIFF
--- a/src/api/album/content-types/album/schema.json
+++ b/src/api/album/content-types/album/schema.json
@@ -15,9 +15,6 @@
     }
   },
   "attributes": {
-    "slug": {
-      "type": "string"
-    },
     "title": {
       "type": "string",
       "required": true,
@@ -27,7 +24,18 @@
         }
       }
     },
+    "slug": {
+      "type": "string"
+    },
     "description": {
+      "type": "text",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "content": {
       "type": "blocks",
       "pluginOptions": {
         "i18n": {
@@ -48,12 +56,6 @@
       "relation": "manyToMany",
       "target": "api::album.track",
       "label": "Tracks"
-    },
-    "pages": {
-      "type": "relation",
-      "relation": "manyToMany",
-      "target": "api::page.page",
-      "label": "Pages"
     },
     "store": {
       "type": "relation",

--- a/src/api/album/content-types/track/schema.json
+++ b/src/api/album/content-types/track/schema.json
@@ -15,9 +15,6 @@
     }
   },
   "attributes": {
-    "slug": {
-      "type": "string"
-    },
     "title": {
       "type": "string",
       "required": true,
@@ -27,7 +24,18 @@
         }
       }
     },
+    "slug": {
+      "type": "string"
+    },
     "description": {
+      "type": "text",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "content": {
       "type": "blocks",
       "pluginOptions": {
         "i18n": {
@@ -53,13 +61,6 @@
     "media": {
       "type": "media",
       "multiple": true
-    },
-    "albums": {
-      "type": "relation",
-      "relation": "manyToMany",
-      "target": "api::album.album",
-      "label": "Albums",
-      "inversedBy": "tracks"
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -385,11 +385,17 @@ export interface ApiAlbumAlbum extends Struct.CollectionTypeSchema {
     };
   };
   attributes: {
+    content: Schema.Attribute.Blocks &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     cover: Schema.Attribute.Media;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
-    description: Schema.Attribute.Blocks &
+    description: Schema.Attribute.Text &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true;
@@ -397,7 +403,6 @@ export interface ApiAlbumAlbum extends Struct.CollectionTypeSchema {
       }>;
     locale: Schema.Attribute.String;
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::album.album'>;
-    pages: Schema.Attribute.Relation<'manyToMany', 'api::page.page'>;
     publishedAt: Schema.Attribute.DateTime;
     SEO: Schema.Attribute.Component<'common.seo', false>;
     slug: Schema.Attribute.String;
@@ -432,11 +437,16 @@ export interface ApiAlbumTrack extends Struct.CollectionTypeSchema {
     };
   };
   attributes: {
-    albums: Schema.Attribute.Relation<'manyToMany', 'api::album.album'>;
+    content: Schema.Attribute.Blocks &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
-    description: Schema.Attribute.Blocks &
+    description: Schema.Attribute.Text &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true;


### PR DESCRIPTION
This pull request includes schema updates for the `album` and `track` content types in the API. The changes involve reordering attributes, adding new fields, and removing unnecessary relations.

Schema updates for `album` content type:

* Reordered the `slug` attribute to be after the `title` attribute. [[1]](diffhunk://#diff-3291670e38876d87fdb1a7ce22a23524ea030e81862bb689514ab9c74245b08fL18-L20) [[2]](diffhunk://#diff-3291670e38876d87fdb1a7ce22a23524ea030e81862bb689514ab9c74245b08fR27-R38)
* Added `description` and `content` attributes with localization options.
* Removed the `pages` relation attribute.

Schema updates for `track` content type:

* Reordered the `slug` attribute to be after the `title` attribute. [[1]](diffhunk://#diff-97790a286ff786cb2bbe29eecabc9720b79d91c6371990987c276c94037485aeL18-L20) [[2]](diffhunk://#diff-97790a286ff786cb2bbe29eecabc9720b79d91c6371990987c276c94037485aeR27-R38)
* Added `description` and `content` attributes with localization options.
* Removed the `albums` relation attribute.