### PR TITLE
Created API form forms & responses

### DIFF
--- a/src/api/forms/content-types/form-response/schema.json
+++ b/src/api/forms/content-types/form-response/schema.json
@@ -1,0 +1,29 @@
+
+{
+  "kind": "collectionType",
+  "collectionName": "form_responses",
+  "info": {
+    "singularName": "form-response",
+    "pluralName": "form-responses",
+    "displayName": "Form Responses"
+  },
+  "options": {
+    "comment": ""
+  },
+  "attributes": {
+    "form": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::forms.forms"
+    },
+    "response": {
+      "type": "json",
+      "required": true
+    },
+    "store": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::store.store"
+    }
+  }
+}

--- a/src/api/forms/content-types/forms/schema.json
+++ b/src/api/forms/content-types/forms/schema.json
@@ -1,0 +1,41 @@
+
+{
+  "kind": "collectionType",
+  "collectionName": "form",
+  "info": {
+    "singularName": "forms",
+    "pluralName": "form",
+    "displayName": "Forms "
+  },
+  "options": {
+    "comment": ""
+  },
+  "attributes": {
+    "Name": {
+      "type": "string",
+      "required": true
+    },
+    "Message": {
+      "type": "text"
+    },
+    "structure": {
+      "type": "json",
+      "required": true
+    },
+    "SEO": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "common.seo"
+    },
+    "store": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::store.store"
+    }
+  }
+}

--- a/src/api/forms/controllers/form-response.ts
+++ b/src/api/forms/controllers/form-response.ts
@@ -1,0 +1,7 @@
+/**
+ *  controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::forms.form-response');

--- a/src/api/forms/controllers/forms.ts
+++ b/src/api/forms/controllers/forms.ts
@@ -1,0 +1,13 @@
+/**
+ * A set of functions called "actions" for `forms`
+ */
+
+export default {
+  // exampleAction: async (ctx, next) => {
+  //   try {
+  //     ctx.body = 'ok';
+  //   } catch (err) {
+  //     ctx.body = err;
+  //   }
+  // }
+};

--- a/src/api/forms/routes/form-response.ts
+++ b/src/api/forms/routes/form-response.ts
@@ -1,0 +1,7 @@
+/**
+ *  router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::forms.form-response');

--- a/src/api/forms/routes/forms.ts
+++ b/src/api/forms/routes/forms.ts
@@ -1,0 +1,13 @@
+export default {
+  routes: [
+    // {
+    //  method: 'GET',
+    //  path: '/forms',
+    //  handler: 'forms.exampleAction',
+    //  config: {
+    //    policies: [],
+    //    middlewares: [],
+    //  },
+    // },
+  ],
+};

--- a/src/api/forms/services/form-response.ts
+++ b/src/api/forms/services/form-response.ts
@@ -1,0 +1,7 @@
+/**
+ *  service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::forms.form-response');

--- a/src/api/forms/services/forms.ts
+++ b/src/api/forms/services/forms.ts
@@ -1,0 +1,5 @@
+/**
+ * forms service
+ */
+
+export default () => ({});

--- a/src/api/inbox/content-types/inbox/schema.json
+++ b/src/api/inbox/content-types/inbox/schema.json
@@ -40,11 +40,6 @@
       "type": "relation",
       "relation": "oneToOne",
       "target": "plugin::users-permissions.user"
-    },
-    "SEO": {
-      "type": "component",
-      "repeatable": false,
-      "component": "common.seo"
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -706,6 +706,72 @@ export interface ApiExtensionExtension extends Struct.SingleTypeSchema {
   };
 }
 
+export interface ApiFormsFormResponse extends Struct.CollectionTypeSchema {
+  collectionName: 'form_responses';
+  info: {
+    displayName: 'Form Responses';
+    pluralName: 'form-responses';
+    singularName: 'form-response';
+  };
+  options: {
+    comment: '';
+    draftAndPublish: false;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    form: Schema.Attribute.Relation<'oneToOne', 'api::forms.forms'>;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::forms.form-response'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    response: Schema.Attribute.JSON & Schema.Attribute.Required;
+    store: Schema.Attribute.Relation<'manyToOne', 'api::store.store'>;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiFormsForms extends Struct.CollectionTypeSchema {
+  collectionName: 'form';
+  info: {
+    displayName: 'Forms ';
+    pluralName: 'form';
+    singularName: 'forms';
+  };
+  options: {
+    comment: '';
+    draftAndPublish: false;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<'oneToMany', 'api::forms.forms'> &
+      Schema.Attribute.Private;
+    Message: Schema.Attribute.Text;
+    Name: Schema.Attribute.String & Schema.Attribute.Required;
+    publishedAt: Schema.Attribute.DateTime;
+    SEO: Schema.Attribute.Component<'common.seo', false> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    store: Schema.Attribute.Relation<'manyToOne', 'api::store.store'>;
+    structure: Schema.Attribute.JSON & Schema.Attribute.Required;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiInboxInbox extends Struct.CollectionTypeSchema {
   collectionName: 'inboxes';
   info: {
@@ -730,7 +796,6 @@ export interface ApiInboxInbox extends Struct.CollectionTypeSchema {
     Name: Schema.Attribute.String & Schema.Attribute.Required;
     parentMessageId: Schema.Attribute.Relation<'oneToOne', 'api::inbox.inbox'>;
     publishedAt: Schema.Attribute.DateTime;
-    SEO: Schema.Attribute.Component<'common.seo', false>;
     store: Schema.Attribute.Relation<'oneToOne', 'api::store.store'>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
@@ -1788,6 +1853,8 @@ declare module '@strapi/strapi' {
       'api::category.category': ApiCategoryCategory;
       'api::event.event': ApiEventEvent;
       'api::extension.extension': ApiExtensionExtension;
+      'api::forms.form-response': ApiFormsFormResponse;
+      'api::forms.forms': ApiFormsForms;
       'api::inbox.inbox': ApiInboxInbox;
       'api::markket.markket': ApiMarkketMarkket;
       'api::order.order': ApiOrderOrder;


### PR DESCRIPTION
This pull request introduces several changes to the `src/api/forms` directory, including the addition of new schemas, controllers, routes, and services for handling form responses and forms. Additionally, there is a modification in the `src/api/inbox/content-types/inbox/schema.json` file.

New schemas:

* [`src/api/forms/content-types/form-response/schema.json`](diffhunk://#diff-5b2c2097061713102f76b72a4d4a69397b930700d6b2b0cb1e50bf911f88ac53R1-R14): Added a new schema for `form-response` collection type.
* [`src/api/forms/content-types/forms/schema.json`](diffhunk://#diff-b6b56ad3ae7487513641a0c9cbe914cfbbb2219cf85235f057595487202dca19R1-R41): Added a new schema for `forms` collection type with attributes including `Name`, `Message`, `structure`, `SEO`, and `store`.

Controllers and services:

* [`src/api/forms/controllers/form-response.ts`](diffhunk://#diff-befca75175d782cf70282c681981da35cff9ebebfae290dd01e212c39c9978b1R1-R7): Added a new controller for `form-response` using Strapi's core controller factory.
* [`src/api/forms/controllers/forms.ts`](diffhunk://#diff-883ecec790e36b617748cfd9f4b284a19eb7bcdf3e306f3a595638069f4a3e88R1-R13): Added a placeholder controller for `forms` with an example action commented out.
* [`src/api/forms/services/form-response.ts`](diffhunk://#diff-d2df4961fab504990f54bcad8e62c338192c858edd81ef135c023a064f265a37R1-R7): Added a new service for `form-response` using Strapi's core service factory.
* [`src/api/forms/services/forms.ts`](diffhunk://#diff-2f204c0f7fdbc2d7ddafca7a2feff5f2ba271ac3cdb7bc40d1d49eabca7ca460R1-R5): Added a new service for `forms` that currently returns an empty object.

Routes:

* [`src/api/forms/routes/form-response.ts`](diffhunk://#diff-8d05fc4bd06f2c9e4a0803f5baebcf75ef6406353343259c994468f73f2141ccR1-R7): Added a new router for `form-response` using Strapi's core router factory.
* [`src/api/forms/routes/forms.ts`](diffhunk://#diff-45e9b036e7d515a8565b1128f365c0a8ef01518d7655aaff2957f344d2508ed2R1-R13): Added a placeholder router for `forms` with an example route commented out.

Modification in existing schema:

* [`src/api/inbox/content-types/inbox/schema.json`](diffhunk://#diff-089dcd316421796550b7271e7357b64c59fb0786fe3aa134eccb666ceb78e28dL43-L47): Removed the `SEO` component from the `inbox` schema.