### PR TITLE
Order notification to store.user[].emails 

### DIFF
--- a/src/api/markket/services/notification/email.template.ts
+++ b/src/api/markket/services/notification/email.template.ts
@@ -43,7 +43,7 @@ export const emailLayout = ({ content, title }: EmailLayout) => {
 /**
  * Order Notification Email Template
  *
- * @param order
+ * @param order Stripe order information, contained in the body
  * @returns
  */
 export const OrderNotificationHTml = (order: any) => {
@@ -74,7 +74,7 @@ export const OrderNotificationHTml = (order: any) => {
  * @returns
  */
 export const RSVPNotificationHTml = (event: any) => {
-  // <p>Order Amount: ${((order?.data?.object?.total_amount || 0) / 100)}</p>
+
   const content = `
     <!--<h1>Order Confirmation</h1>
     <p>Thank you for your order!</p>
@@ -91,6 +91,30 @@ export const RSVPNotificationHTml = (event: any) => {
   `;
 
   const title = 'Markkët: RSVP Confirmation';
+
+  return emailLayout({ content, title });
+};
+
+/**
+ * Notifies Store.user[].email about a purchase
+ *
+ * @param order, store
+ * @returns
+ */
+export const OrderStoreNotificationEmailHTML = (order: { documentId: string, Amount: number, }, store: { title: string, documentId: string }) => {
+  console.log({ order });
+
+  const content = `
+    <h2>You must construct additional pylons</h2>
+    <p>A new order has been placed in your store: ${store.title}</p>
+    <p><strong>$${order?.Amount}</strong></p>
+    <p>order id: ${order?.documentId}</p>
+    <p>Visit the Dashboard to view details</p>
+    <a href="https://de.markket.place/dashboard/crm?store=${store?.documentId}&order_id=${order.documentId}#orders">/dashboard/crm</a>
+    </div>
+  `;
+
+  const title = 'Markkët: Order notification';
 
   return emailLayout({ content, title });
 };

--- a/src/api/markket/services/notification/index.ts
+++ b/src/api/markket/services/notification/index.ts
@@ -1,6 +1,6 @@
 const SENDGRID_FROM_EMAIL = process.env.SENDGRID_FROM_EMAIL || '';
 const SENDGRID_REPLY_TO_EMAIL = process.env.SENDGRID_REPLY_TO_EMAIL || '';
-import { OrderNotificationHTml, RSVPNotificationHTml } from './email.template';
+import { OrderNotificationHTml, RSVPNotificationHTml, OrderStoreNotificationEmailHTML } from './email.template';
 
 
 export const sendRSVPNotification = async ({ strapi, rsvp, event }) => {
@@ -35,9 +35,32 @@ export const sendRSVPNotification = async ({ strapi, rsvp, event }) => {
 };
 
 
+export const notifyStoreOfPurchase = async ({ strapi, order, emails, store }) => {
+  console.info('notification::store:purchase', {
+    order: order?.documentId || order?.id,
+    strapi: !!strapi,
+    from: !!SENDGRID_FROM_EMAIL,
+    reply_to: !!SENDGRID_REPLY_TO_EMAIL,
+  });
+
+  if (!SENDGRID_FROM_EMAIL || !SENDGRID_REPLY_TO_EMAIL) {
+    return;
+  }
+
+  return await strapi.plugins['email'].services.email.send({
+    to: emails,
+    from: SENDGRID_FROM_EMAIL,
+    cc: SENDGRID_REPLY_TO_EMAIL,
+    replyTo: SENDGRID_REPLY_TO_EMAIL,
+    subject: 'Markkët: Order Notification',
+    text: 'New order in your store! - log in to view details',
+    html: OrderStoreNotificationEmailHTML(order, store),
+  });
+};
+
 export const sendOrderNotification = async ({ strapi, order }) => {
   console.info('notification::stripe:checkout.session.completed', {
-    order,
+    order: order?.documentId || order?.id,
     strapi: !!strapi,
     from: !!SENDGRID_FROM_EMAIL,
     reply_to: !!SENDGRID_REPLY_TO_EMAIL,


### PR DESCRIPTION
During the purchase flow, stripe send a webhook 

We find the order associated in the request, to mark status as complete 

This pull request finds the users associated with the store, and emails them a link to view order details 

