### PR TITLE
forcing SEO.social image into populate

### DIFF
--- a/docs/TIENDA_API.md
+++ b/docs/TIENDA_API.md
@@ -21,6 +21,7 @@ The `:ref` param accepts either a **documentId** or a **slug** on all store-scop
 | `PUT` | `/api/tienda/stores/:ref` | `{ title?, slug?, … }` | Update store fields |
 | `GET` | `/api/tienda/stores/:ref/settings` | — | Get store settings |
 | `PUT` | `/api/tienda/stores/:ref/settings` | `{ … }` | Update store settings |
+| `GET` | `/api/tienda/tendero/:ref` | — | Lightweight ownership check — returns `{ ok, store: { documentId, slug } }` |
 
 ---
 
@@ -31,9 +32,9 @@ See [TIENDA_CONTENT_ENDPOINTS.md](./TIENDA_CONTENT_ENDPOINTS.md) for the full co
 
 | Method | Path | Body / Query | Description |
 |---|---|---|---|
-| `GET` | `/api/tienda/stores/:ref/content/:type` | `?status=draft\|published&search=&page=&pageSize=` | List items — returns draft + published state per item |
+| `GET` | `/api/tienda/stores/:ref/content/:type` | `?status=draft\|published&search=&page=&pageSize=&filters[…]=…&populate=…` | List items — returns draft + published state per item |
 | `POST` | `/api/tienda/stores/:ref/content/:type` | `{ …fields, publishNow?: true }` | Create item, optionally publish immediately |
-| `GET` | `/api/tienda/stores/:ref/content/:type/:itemId` | `?status=draft\|published` | Get single item |
+| `GET` | `/api/tienda/stores/:ref/content/:type/:itemId` | `?status=draft\|published&populate=…` | Get single item |
 | `PUT` | `/api/tienda/stores/:ref/content/:type/:itemId` | `{ …fields, publishNow?: true, unpublishNow?: true, saveAsDraft?: true }` | Update — pass `publishNow` or `unpublishNow` to change publish state |
 | `DELETE` | `/api/tienda/stores/:ref/content/:type/:itemId` | `{ hard?: true }` | Soft-delete (unpublish) by default; `hard: true` to permanently delete |
 
@@ -45,8 +46,8 @@ Every content item includes a `tiendaPublication` block:
 {
   "tiendaPublication": {
     "hasDraft": true,
-    "hasPublished": false,
-    "visibleStatus": "unpublished"
+    "hasPublished": true,
+    "visibleStatus": "draft"
   }
 }
 ```
@@ -55,9 +56,40 @@ Every content item includes a `tiendaPublication` block:
 
 | Value | Meaning |
 |---|---|
-| `published` | Live, no pending draft |
-| `draft` | Published but has unpublished edits |
-| `unpublished` | Never published or actively unpublished |
+| `published` | Live, no unsaved edits |
+| `draft` | Live **and** has pending unpublished edits — dashboard shows the draft for preview/editing |
+| `unpublished` | Only a draft exists (never published) or was soft-deleted |
+
+Public storefront consumers should always request `?status=published`. The owner dashboard omits `status` to get the merged preview view.
+
+### SEO & social image
+
+All SEO-enabled types always return a populated `SEO.socialImage` — no extra populate param needed:
+
+```json
+{
+  "SEO": {
+    "metaTitle": "…",
+    "metaDescription": "…",
+    "socialImage": { "url": "https://…", "width": 1200, "height": 630 },
+    "metaUrl": "…",
+    "metaAuthor": "…",
+    "excludeFromSearch": false
+  }
+}
+```
+
+Use `SEO.socialImage` for `og:image` / Twitter card meta tags.
+
+### Extra populate & filters
+
+Both list and single-item endpoints accept `populate` and `filters` query params merged safely with the mandatory store scope:
+
+```
+?populate=cover,Tags&filters[active][$eq]=true
+```
+
+Store ownership scoping is always enforced regardless of client filters.
 
 ---
 

--- a/docs/TIENDA_CONTENT_ENDPOINTS.md
+++ b/docs/TIENDA_CONTENT_ENDPOINTS.md
@@ -61,7 +61,9 @@ List all items of a specific type for a store with pagination, search, and filte
 - `page` (int, default: 1) - Page number
 - `pageSize` (int, default: 25, max: 100) - Items per page
 - `search` (string) - Search across title, keywords, description
-- `status` (string) - Filter by `draft` or `published` (only for draftAndPublish types)
+- `status` (string) - Filter by `draft` or `published` (only for draftAndPublish types); omit for merged owner preview view
+- `filters` (object) - Additional Strapi-style filters merged with mandatory store scope e.g. `filters[active][$eq]=true`
+- `populate` (string/object) - Extra relations to populate, merged with defaults; `SEO` and `SEO.socialImage` are always included
 
 **Example Request:**
 ```bash

--- a/src/api/tienda/content-registry.ts
+++ b/src/api/tienda/content-registry.ts
@@ -32,7 +32,7 @@ export const CONTENT_TYPES: Record<string, ContentTypeConfig> = {
     mutableFields: ['Title', 'slug', 'Content', 'cover', 'Tags', 'SEO', 'category', 'description', 'keywords'],
     readOnlyFields: ['Creator'],
     autoSetCreator: 'Creator',
-    defaultPopulate: ['cover', 'Tags', 'SEO', 'category', 'Creator', 'store'],
+    defaultPopulate: ['cover', 'Tags', 'SEO', 'SEO.socialImage', 'category', 'Creator', 'store'],
     mediaFields: ['cover'],
     relationFields: ['category'],
     componentFields: ['Tags'],
@@ -46,7 +46,7 @@ export const CONTENT_TYPES: Record<string, ContentTypeConfig> = {
     hasDraftAndPublish: true,
     mutableFields: ['Title', 'slug', 'Content', 'Active', 'menuOrder', 'SEO', 'albums', 'description', 'keywords'],
     autoSetCreator: 'owner',
-    defaultPopulate: ['SEO', 'albums', 'creator', 'owner', 'store'],
+    defaultPopulate: ['SEO', 'SEO.socialImage', 'albums', 'creator', 'owner', 'store'],
     relationFields: ['albums'],
   },
   album: {
@@ -58,7 +58,7 @@ export const CONTENT_TYPES: Record<string, ContentTypeConfig> = {
     hasDraftAndPublish: true,
     mutableFields: ['title', 'slug', 'description', 'content', 'SEO', 'cover', 'tracks', 'keywords'],
     autoSetCreator: 'owner',
-    defaultPopulate: ['cover', 'SEO', 'tracks', 'owner', 'store'],
+    defaultPopulate: ['cover', 'SEO', 'SEO.socialImage', 'tracks', 'owner', 'store'],
   },
   track: {
     uid: 'api::album.track',
@@ -69,7 +69,7 @@ export const CONTENT_TYPES: Record<string, ContentTypeConfig> = {
     hasDraftAndPublish: true,
     mutableFields: ['title', 'slug', 'description', 'content', 'SEO', 'media', 'urls', 'keywords'],
     autoSetCreator: 'owner',
-    defaultPopulate: ['media', 'SEO', 'urls', 'owner', 'store'],
+    defaultPopulate: ['media', 'SEO', 'SEO.socialImage', 'urls', 'owner', 'store'],
   },
   category: {
     uid: 'api::category.category',
@@ -80,7 +80,7 @@ export const CONTENT_TYPES: Record<string, ContentTypeConfig> = {
     hasDraftAndPublish: true,
     mutableFields: ['Name', 'slug', 'Description', 'SEO', 'Active', 'keywords'],
     autoSetCreator: 'owner',
-    defaultPopulate: ['SEO', 'articles', 'owner', 'store'],
+    defaultPopulate: ['SEO', 'SEO.socialImage', 'articles', 'owner', 'store'],
   },
   product: {
     uid: 'api::product.product',
@@ -95,7 +95,7 @@ export const CONTENT_TYPES: Record<string, ContentTypeConfig> = {
     ],
     readOnlyFields: ['SKU', 'slug'], // SKU is auto-synced with Stripe, slug is UID field
     autoSetCreator: 'creator',
-    defaultPopulate: ['Thumbnail', 'Slides', 'SEO', 'Tag', 'PRICES', 'stores', 'creator'],
+    defaultPopulate: ['Thumbnail', 'Slides', 'SEO', 'SEO.socialImage', 'Tag', 'PRICES', 'stores', 'creator'],
     mediaFields: ['Thumbnail', 'Slides'],
     componentFields: ['Tag', 'PRICES'],
   },
@@ -112,7 +112,7 @@ export const CONTENT_TYPES: Record<string, ContentTypeConfig> = {
     ],
     readOnlyFields: ['STRIPE_PRODUCT_ID', 'slug', 'amountSold'],
     autoSetCreator: 'creator',
-    defaultPopulate: ['Thumbnail', 'Slides', 'SEO', 'Tag', 'PRICES', 'stores', 'creator'],
+    defaultPopulate: ['Thumbnail', 'Slides', 'SEO', 'SEO.socialImage', 'Tag', 'PRICES', 'stores', 'creator'],
     mediaFields: ['Thumbnail', 'Slides'],
     componentFields: ['Tag', 'PRICES'],
   },

--- a/src/api/tienda/controllers/tienda.ts
+++ b/src/api/tienda/controllers/tienda.ts
@@ -49,6 +49,79 @@ const CONTENT_TYPE_ALIASES: Record<string, string> = {
   shortners: 'shortner',
 };
 
+const FORCED_CONTENT_POPULATE_FIELDS = ['SEO', 'SEO.socialImage'];
+
+function normalizePopulatePath(value: unknown): string[] {
+  if (typeof value !== 'string') {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(Boolean);
+}
+
+function collectPopulateFields(input: unknown, parentPath = ''): string[] {
+  if (input == null || input === false) {
+    return [];
+  }
+
+  if (typeof input === 'string') {
+    const normalized = input.trim().toLowerCase();
+    if (normalized === 'true') {
+      return parentPath ? [parentPath] : [];
+    }
+    if (normalized === 'false') {
+      return [];
+    }
+    return normalizePopulatePath(input);
+  }
+
+  if (typeof input === 'number') {
+    return input > 0 && parentPath ? [parentPath] : [];
+  }
+
+  if (Array.isArray(input)) {
+    return input.flatMap(entry => collectPopulateFields(entry, parentPath));
+  }
+
+  if (typeof input === 'object') {
+    return Object.entries(input as Record<string, unknown>).flatMap(([rawKey, rawValue]) => {
+      const key = String(rawKey).trim();
+      if (!key) {
+        return [];
+      }
+
+      // Support qs-style formats: populate[SEO][populate][0]=socialImage
+      if (key === 'populate') {
+        return collectPopulateFields(rawValue, parentPath);
+      }
+
+      // Numeric keys are list indexes from query parser.
+      if (/^\d+$/.test(key)) {
+        return collectPopulateFields(rawValue, parentPath);
+      }
+
+      const nextPath = parentPath ? `${parentPath}.${key}` : key;
+      const nested = collectPopulateFields(rawValue, nextPath);
+      return nested.length > 0 ? nested : [nextPath];
+    });
+  }
+
+  return [];
+}
+
+function resolveContentPopulate(defaultPopulate: string[], requestedPopulate: unknown): string[] {
+  const merged = new Set<string>([
+    ...defaultPopulate,
+    ...collectPopulateFields(requestedPopulate),
+    ...FORCED_CONTENT_POPULATE_FIELDS,
+  ]);
+
+  return Array.from(merged);
+}
+
 type StarterPageTemplate = {
   Title: string;
   slug: string;
@@ -550,7 +623,7 @@ async function findOwnerContentItem(
   documentsApi: any,
   config: any,
   documentId: string,
-  populate: string[],
+  populate: any,
   requestedStatus: 'draft' | 'published' | null,
   locale?: string,
 ) {
@@ -1079,9 +1152,21 @@ export default {
       const { skip, limit } = applyPagination(ctx);
       const requestedStatus = resolveRequestedPublicationStatus(ctx.query.status);
       const documentsApi = (strapi.documents as any)(config.uid);
+      const populate = resolveContentPopulate(config.defaultPopulate, ctx.query.populate);
+      const storeFilter = buildStoreFilter(access.store.documentId, config);
+      const clientFilters =
+        ctx.query.filters && typeof ctx.query.filters === 'object' && !Array.isArray(ctx.query.filters)
+          ? ctx.query.filters
+          : null;
+      const filterClauses: any[] = [storeFilter];
+
+      if (clientFilters) {
+        filterClauses.push(clientFilters);
+      }
+
       const query: any = {
-        filters: buildStoreFilter(access.store.documentId, config),
-        populate: config.defaultPopulate,
+        filters: filterClauses.length === 1 ? filterClauses[0] : { $and: filterClauses },
+        populate,
       };
 
       // Apply search if provided
@@ -1089,14 +1174,15 @@ export default {
         const searchTerm = String(ctx.query.search).trim();
         if (searchTerm.length > 0) {
           const titleField = config.titleField;
-          query.filters = {
-            ...query.filters,
+          filterClauses.push({
             $or: [
               { [titleField]: { $containsi: searchTerm } },
               { keywords: { $containsi: searchTerm } }, // Search tags/keywords too
               { description: { $containsi: searchTerm } },
             ],
-          };
+          });
+
+          query.filters = filterClauses.length === 1 ? filterClauses[0] : { $and: filterClauses };
         }
       }
 
@@ -1238,6 +1324,7 @@ export default {
       const access = await checkStoreAccess(strapi, user.id, ref);
       const requestedStatus = resolveRequestedPublicationStatus(ctx.query.status);
       const documentsApi = (strapi.documents as any)(config.uid);
+      const populate = resolveContentPopulate(config.defaultPopulate, ctx.query.populate);
 
       if (!access.hasAccess) {
         return ctx.forbidden(ERRORS.STORE_NOT_FOUND);
@@ -1247,7 +1334,7 @@ export default {
         documentsApi,
         config,
         itemId,
-        config.defaultPopulate,
+        populate,
         requestedStatus,
       );
 


### PR DESCRIPTION
This pull request enhances how content population fields are handled in the tienda API. The main improvement is the introduction of a more flexible and robust way to determine which related fields are populated in content queries, ensuring that essential SEO-related fields are always included. This is achieved by merging default, requested, and forced populate fields, and by normalizing and flattening the structure of requested populate fields from the API client.

Key changes include:

**Content Population Logic Improvements:**

* Added a new utility (`resolveContentPopulate`) that merges default populate fields, client-requested populate fields (from query parameters), and a set of forced fields (including `SEO` and `SEO.socialImage`). This ensures these SEO fields are always included in content queries, regardless of client input.
* Implemented helper functions (`normalizePopulatePath`, `collectPopulateFields`) to robustly parse and flatten different formats of populate request parameters, supporting nested and array structures.

**API Endpoint Updates:**

* Updated all relevant API controller logic to use the new `resolveContentPopulate` when building queries, replacing direct use of `config.defaultPopulate`. This ensures consistent population of required fields in all content retrieval endpoints. [[1]](diffhunk://#diff-d0114d3a3ef77fabef1be960d286d9affb09204dc88f744c65bbec4316e1e278R1155-R1185) [[2]](diffhunk://#diff-d0114d3a3ef77fabef1be960d286d9affb09204dc88f744c65bbec4316e1e278R1327) [[3]](diffhunk://#diff-d0114d3a3ef77fabef1be960d286d9affb09204dc88f744c65bbec4316e1e278L1250-R1337)
* Modified the `findOwnerContentItem` function and related calls to accept the new, dynamically resolved populate list.

**Content Type Config Updates:**

* Updated the `defaultPopulate` arrays in all content type configurations in `content-registry.ts` to explicitly include `SEO.socialImage`, ensuring this field is always available by default. [[1]](diffhunk://#diff-a9b5b2bc5dca08bb4414f8d1abc31d424fe2485986c78aee5b69405c669036d4L35-R35) [[2]](diffhunk://#diff-a9b5b2bc5dca08bb4414f8d1abc31d424fe2485986c78aee5b69405c669036d4L49-R49) [[3]](diffhunk://#diff-a9b5b2bc5dca08bb4414f8d1abc31d424fe2485986c78aee5b69405c669036d4L61-R61) [[4]](diffhunk://#diff-a9b5b2bc5dca08bb4414f8d1abc31d424fe2485986c78aee5b69405c669036d4L72-R72) [[5]](diffhunk://#diff-a9b5b2bc5dca08bb4414f8d1abc31d424fe2485986c78aee5b69405c669036d4L83-R83) [[6]](diffhunk://#diff-a9b5b2bc5dca08bb4414f8d1abc31d424fe2485986c78aee5b69405c669036d4L98-R98) [[7]](diffhunk://#diff-a9b5b2bc5dca08bb4414f8d1abc31d424fe2485986c78aee5b69405c669036d4L115-R115)